### PR TITLE
Ignore upgrading mui data grid pro

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,7 +16,9 @@
     "starlette",
     "urllib3",
     "uvicorn",
-    "@mui/x-data-grid"
+    "@mui/x-data-grid",
+    "@mui/x-data-grid-pro",
+    "@mui/x-license"
   ],
   "minimumReleaseAge": "1 day",
   "packageRules": [


### PR DESCRIPTION
@mui/x-data-grid-pro upgrades should be treated the same as @mui/x-data-grid